### PR TITLE
[CDAP-18014] Only handle response on 200 success code

### DIFF
--- a/src/main/java/io/cdap/plugin/http/HTTPArgumentSetter.java
+++ b/src/main/java/io/cdap/plugin/http/HTTPArgumentSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/src/main/java/io/cdap/plugin/http/HTTPArgumentSetter.java
+++ b/src/main/java/io/cdap/plugin/http/HTTPArgumentSetter.java
@@ -72,8 +72,8 @@ public abstract class HTTPArgumentSetter<T extends HTTPConfig> extends Action {
         int responseCode = response.getResponseCode();
 
         LOG.debug("Request to {} resulted in response code {}.", conf.getUrl(), responseCode);
-        if (responseCode / 100 != 2) {
-          throw new IllegalStateException(String.format("Received non-ok response code %d. Response message = %s",
+        if (responseCode != 200) {
+          throw new IllegalStateException(String.format("Received non-200 response code %d. Response message = %s",
                                                         responseCode, response.getResponseMessage()));
         }
         handleResponse(context, response.getResponseBodyAsString());


### PR DESCRIPTION
Update HttpArgumentSetter to only handle responses with 200 success code and throw exception for all other responses

JIRA: https://cdap.atlassian.net/browse/CDAP-18014